### PR TITLE
Fix domain redirect when behind proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ class DatGateway extends DatLibrarian {
           return DatLibrarian.resolve(address).then((resolvedAddress) => {
             // TODO: Detect DatDNS addresses
             let encodedAddress = hexTo32.encode(resolvedAddress)
-            let redirectURL = `http://${encodedAddress}.${urlParts.hostname}:${this.server.address().port}/${path}${urlParts.search || ''}`
+            let redirectURL = `http://${encodedAddress}.${urlParts.host}/${path}${urlParts.search || ''}`
 
             log('Redirecting %s to %s', address, redirectURL)
             res.setHeader('Location', redirectURL)


### PR DESCRIPTION
I'm running a public gateway using `--redirect` from behind an Nginx reverse proxy, over at [https://pamphlets.me](https://pamphlets.me). To make this setup work a fix is needed though, redirecting to `urlParts.host` instead of `urlParts.hostname + port`, because the port known to node is the wrong one when running behind a reverse proxy.