### PR TITLE
Improve handling of 500 errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ class DatGateway extends DatLibrarian {
         let address = isRedirecting ? hexTo32.decode(subdomain) : pathParts[0]
         let path = (isRedirecting ? pathParts : pathParts.slice(1)).join('/')
 
+        const logError = (err, end) => log('[%s] %s %s | ERROR %s [%i ms]', address, req.method, path, err.message, end - start)
         log('[%s] %s %s', address, req.method, path)
 
         // return index
@@ -166,8 +167,10 @@ class DatGateway extends DatLibrarian {
             res.writeHead(302)
             res.end()
           }).catch((e) => {
+            const end = Date.now()
+            logError(e, end)
             res.writeHead(500)
-            res.end(JSON.stringify(e))
+            res.end(e.message)
           })
         }
 
@@ -179,8 +182,10 @@ class DatGateway extends DatLibrarian {
             res.writeHead(200)
             res.end(`dat://${resolvedAddress}\nttl=3600`)
           }).catch((e) => {
+            const end = Date.now()
+            logError(e, end)
             res.writeHead(500)
-            res.end(JSON.stringify(e))
+            res.end(e.message)
           })
         }
 
@@ -193,13 +198,13 @@ class DatGateway extends DatLibrarian {
           dat.onrequest(req, res)
         }).catch((e) => {
           const end = Date.now()
-          log('[%s] %s %s | ERROR %s [%i ms]', address, req.method, path, e.message, end - start)
+          logError(e, end)
           if (e.message.indexOf('not found') > -1) {
             res.writeHead(404)
             res.end('Not found')
           } else {
             res.writeHead(500)
-            res.end(JSON.stringify(e))
+            res.end(e.message)
           }
         })
       }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const url = require('url')
 const hexTo32 = require('hex-to-32')
 
 const BASE_32_KEY_LENGTH = 52
+const ERR_404 = 'Not found'
+const ERR_500 = 'Server error'
 
 function log () {
   let msg = arguments[0]
@@ -170,7 +172,7 @@ class DatGateway extends DatLibrarian {
             const end = Date.now()
             logError(e, end)
             res.writeHead(500)
-            res.end(e.message)
+            res.end(ERR_500)
           })
         }
 
@@ -185,7 +187,7 @@ class DatGateway extends DatLibrarian {
             const end = Date.now()
             logError(e, end)
             res.writeHead(500)
-            res.end(e.message)
+            res.end(ERR_500)
           })
         }
 
@@ -201,10 +203,10 @@ class DatGateway extends DatLibrarian {
           logError(e, end)
           if (e.message.indexOf('not found') > -1) {
             res.writeHead(404)
-            res.end('Not found')
+            res.end(ERR_404)
           } else {
             res.writeHead(500)
-            res.end(e.message)
+            res.end(ERR_500)
           }
         })
       }


### PR DESCRIPTION
This address the problem with [stringifying server errors](https://github.com/RangerMauve/dat-gateway/pull/14#issuecomment-397054796). Right now I've chosen to send `err.message` as a response to the client, but maybe it's better to return a more generic 'Server error' style message, to avoid unwanted information leaking out.